### PR TITLE
Update agent

### DIFF
--- a/agent
+++ b/agent
@@ -9,7 +9,7 @@ fi
  
 MASTER_HOSTNAME=$1
  
-yum install -y http://yum.puppetlabs.com/puppetlabs-release-el-7.noarch.rpm || true
+yum install -y http://yum.puppetlabs.com/puppetlabs-release-el-6.noarch.rpm || true
 yum -y install puppet
  
 echo "[main]


### PR DESCRIPTION
Your agent install got changed to CentOS 7 even for the CentOS 6 file. This just switches it back so we can continue to use the script for CentOS 6.
